### PR TITLE
updated readme with proxy setup instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ## Setup
 - Clone the repository
 - Run `npm install`
+- If working behind a proxy:- Set OS global env variable 'http_proxy'=<proxy address:port>
 
 ## Running Tests
 


### PR DESCRIPTION
the setup instructions do not work when using newman behind corporate proxy. Adding additional step in instructions to make this work